### PR TITLE
サイト全体にBasic認証を適用する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :basic_authentication if Rails.env.production?
   before_action :authenticate_user!
+
+  private
+
+  def basic_authentication
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,6 @@ class User < ApplicationRecord
   end
 
   def followed?(follow_user)
-    !!follows.find_by(follow_user_id: follow_user.id)
+    !follows.find_by(follow_user_id: follow_user.id).nil?
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
     name { Faker::Alphanumeric.alpha(number: 10) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
https://github.com/dobby618/tryout-miniblog/issues/11

- [x] α版として一般に公開するため、サイト全体にBasic認証を適用する
　・RAILS_ENVがproductionの場合のみサイト全体にBasic認証が適用されるようにすること
　・Basic認証に利用するユーザー名、パスワードは環境変数で管理できるようにすること（ユーザー名、パスワードを平文でGithubで管理しないようにするため）