### PR TITLE
他ユーザーの投稿にコメントできるようにする

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,10 @@ Style/ClassAndModuleChildren:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
+# if 文を rubocop:disable にすると end の後にコメントを書く必要があるため
+Style/CommentedKeyword:
+  Enabled: false
+
 ################
 # Layout #
 ################

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CommentsController < ApplicationController
+  before_action :authenticate_user!, except: [:index]
+  before_action :set_article
+
+  def index
+  end
+
+  def create
+    comment = @article.comments.create(comment_params)
+
+    if comment.errors.blank?
+      # 自分の投稿にコメントした場合は、メール通知しない
+      # 自分だったら他人にしたくない？
+      ArticleMailer.commented(@article, comment).deliver_now if @article.user != current_user
+    else
+      flash[:alert] = comment.errors.full_messages
+    end
+
+    redirect_back fallback_location: root_url
+  end
+
+  private
+
+  def set_article
+    @article = Article.find(params[:article_id])
+  end
+
+  def comment_params
+    params.require(:comment).permit(:body).merge(user: current_user)
+  end
+end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -6,7 +6,7 @@ class FollowsController < ApplicationController
   def create
     Follow.create(user_id: current_user.id, follow_user_id: params[:user_id]) unless @follow
 
-    redirect_to profile_path(current_user.name)
+    redirect_back fallback_location: root_url
   end
 
   def destroy

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]
+
+  def create
+    super
+  end
 
   def update
     super
@@ -9,8 +14,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   private
 
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email])
+  end
+
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:profile, :website])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:email, :profile, :website])
   end
 
   def update_resource(resource, params)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'no-reply@herokuapp.com'
   layout 'mailer'
+  helper :application
 end

--- a/app/mailers/article_mailer.rb
+++ b/app/mailers/article_mailer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ArticleMailer < ApplicationMailer
+  default template_path: "mailers/#{name.underscore}"
+
+  def commented(article, comment)
+    @article = article
+    @comment = comment
+
+    mail(to: article.user.email, subject: 'コメントが届きました')
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -5,6 +5,7 @@ class Article < ApplicationRecord
 
   belongs_to :user
   has_many :likes, dependent: :destroy
+  has_many :comments, dependent: :destroy
 
   validates :body, presence: true,
                    length: { maximum: 140 }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  belongs_to :article, counter_cache: true
+  belongs_to :user
+
+  validates :body, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   validates :name, length: { maximum: 20 },
                    format: { with: /\A[a-zA-Z]+\z/ },
                    uniqueness: { case_sensitive: false }
+  validates :email, presence: true
   validates :website, format: /\A#{URI.regexp(%w[http https])}\z/, allow_blank: true
 
   def email_required?

--- a/app/views/articles/_article.html.haml
+++ b/app/views/articles/_article.html.haml
@@ -25,3 +25,9 @@
         = link_to article_like_path(article), method: :article do
           %i.far.fa-heart
       = link_to article.likes_count, article_like_path(article)
+
+    // コメント
+    .float-right.mr-2
+      = link_to article_comments_path(article) do
+        %i.far.fa-comments
+        = article.comments_count

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -1,0 +1,20 @@
+%h2 コメント
+
+= render 'articles/article', article: @article
+
+- if @article.comments.select(&:persisted?).present?
+  %ul.list-group.list-group-flush
+    - @article.comments.includes(:user).select(&:persisted?).each do |comment|
+      %li.list-group-item
+        = nl2br comment.body
+        .float-right= link_to "by #{comment.user.name}", profile_path(comment.user)
+
+- if user_signed_in?
+  = form_for @article.comments.build, url: article_comments_path(@article) do |f|
+    .input-group
+      = f.text_area :body, class: 'form-control', rows: '1'
+      .input-group-append
+        = f.submit 'コメント', class: 'btn btn-outline-secondary'
+- else
+  = link_to 'ログイン', user_session_path
+  するとコメントできるようになります。

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,7 +20,13 @@
       - if notice.present?
         .alert.alert-info= notice
       - if alert.present?
-        .alert.alert-danger= alert
+        .alert.alert-danger
+          - if alert.is_a?(Array)
+            %ul
+              - alert.each do |message|
+                %li= message
+          - else
+            = alert
 
       .row.justify-content-center
         .col-md-8

--- a/app/views/mailers/article_mailer/commented.html.haml
+++ b/app/views/mailers/article_mailer/commented.html.haml
@@ -1,0 +1,3 @@
+%p= nl2br @comment.body
+
+= link_to 'コメントを Web で確認する', article_comments_url(@article)

--- a/app/views/profile/show.html.haml
+++ b/app/views/profile/show.html.haml
@@ -2,8 +2,7 @@
   = link_to '編集', edit_user_registration_path
 
 %ul.list-group.list-group-flush
-  %li.list-group-item
-    = @user.name
+  %li.list-group-item= @user.name
   - if @user.profile
     %li.list-group-item= nl2br @user.profile
   - if @user.website

--- a/app/views/users/registrations/edit.html.haml
+++ b/app/views/users/registrations/edit.html.haml
@@ -4,6 +4,9 @@
 = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, class: 'px-4 py-3') do |f|
   = render 'users/shared/error_messages', resource: resource
   .form-group
+    = f.label :email
+    = f.email_field :email, autocomplete: 'email', class: 'form-control'
+  .form-group
     = f.label :profile
     = f.text_area :profile, autocomplete: 'profile', class: 'form-control'
   .form-group

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -6,6 +6,9 @@
     = f.label :name
     = f.text_field :name, autofocus: true, autocomplete: 'name', class: 'form-control'
   .form-group
+    = f.label :email
+    = f.email_field :email, autocomplete: 'email', class: 'form-control'
+  .form-group
     = f.label :password
     = f.password_field :password, autocomplete: 'current-password', class: 'form-control'
   .form-group

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,6 +91,19 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  config.action_mailer.default_url_options = { host: 'https://tryout-miniblog2.herokuapp.com' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.smtp_settings = {
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: 'herokuapp.com',
+    address: 'smtp.sendgrid.net',
+    port: 587,
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'from@example.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -183,7 +183,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -8,6 +8,7 @@ ja:
         body: 投稿内容
       user:
         name: ユーザ名
+        email: メールアドレス
         password: パスワード
         password_confirmation: パスワード（確認）
         profile: プロフィール

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root 'articles#index'
   resources :articles, only: [:index, :new, :create, :destroy] do
     resource :like, only: [:show, :create, :destroy]
+    resources :comments, only: [:index, :create]
   end
   resources :profile, param: :name, only: [:show]
   resource  :follow, only: [:create, :destroy]

--- a/db/migrate/20200718221404_create_comments.rb
+++ b/db/migrate/20200718221404_create_comments.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateComments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :comments do |t|
+      t.references :article, null: false, foreign_key: true
+      t.references :user,    null: false, foreign_key: true
+      t.text       :body,    null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200719015424_add_article_comments_count_to_post.rb
+++ b/db/migrate/20200719015424_add_article_comments_count_to_post.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddArticleCommentsCountToPost < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :comments_count, :integer, null: false, default: 0, after: :likes_count
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_17_221426) do
+ActiveRecord::Schema.define(version: 2020_07_19_015424) do
 
   create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.text "body"
     t.bigint "user_id", null: false
     t.integer "likes_count", default: 0, null: false
+    t.integer "comments_count", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "image"
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.bigint "user_id", null: false
+    t.text "body", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["article_id"], name: "index_comments_on_article_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "follows", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
@@ -54,6 +65,8 @@ ActiveRecord::Schema.define(version: 2020_07_17_221426) do
   end
 
   add_foreign_key "articles", "users"
+  add_foreign_key "comments", "articles"
+  add_foreign_key "comments", "users"
   add_foreign_key "follows", "users"
   add_foreign_key "follows", "users", column: "follow_user_id"
   add_foreign_key "likes", "articles"

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :comment do
+    article
+    user
+    body { Faker::Name.name }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :user do
     name { Faker::Alphanumeric.alpha(number: 10) }
+    email { Faker::Internet.email }
     password { Faker::Alphanumeric.alpha(number: 10) }
     profile { Faker::Name.name }
     website { Faker::Internet.url }

--- a/spec/mailers/previews/article_mailer_preview.rb
+++ b/spec/mailers/previews/article_mailer_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/article_mailer
+class ArticleMailerPreview < ActionMailer::Preview
+  def commented
+    ArticleMailer.commented(Article.first, Article.first.comments.last)
+  end
+end

--- a/spec/requests/comment_spec.rb
+++ b/spec/requests/comment_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Comment', type: :request do
+  describe 'POST #create' do
+    let(:current_user) { create(:user) }
+
+    before do
+      login_user(current_user)
+    end
+
+    context '自分以外のユーザにコメントした場合' do
+      let(:article) { create(:article, user: create(:user)) }
+      let(:params) { { comment: { body: Faker::Name.name } } }
+
+      it '通知メールを送信する' do
+        expect do
+          post article_comments_url(article, params)
+        end.to change(ActionMailer::Base.deliveries, :size).by(1)
+      end
+    end
+
+    context '自分の投稿にコメントした場合' do
+      let(:article) { create(:article, user: current_user) }
+      let(:params) { { comment: { body: Faker::Name.name } } }
+
+      it '通知メールを送信しない' do
+        expect do
+          post article_comments_url(article, params)
+        end.not_to change(ActionMailer::Base.deliveries, :size)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/dobby618/tryout-miniblog/issues/23

- [x] 各投稿にコメントができるように
    - [x] テーブル作成
    - [x] コメント機能・コメント表示機能実装
- [x] コメントされたら投稿主にメール通知されるように
    - [x] 会員登録でメールの登録を必須にする
    - [x] 自分の投稿にコメントした場合は、メール通知しない
    - [x] 開発環境でメール文面を確認する際はActionMailer Previewを利用すること
    - [x] 1 投稿のコメント一覧を確認するページを作る。
        - [x] post_comments カラムを作る
- [x] メールの送信にはSendgridを利用すること（Herokuプラグイン）
[RailsでHerokuのSendGridアドオンを使ってみる](http://sprink.hatenablog.com/entry/2018/02/28/211223)