### PR TITLE
rubocop、heroku デプロイの自動化

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,16 @@
+# https://www.takayasugiyama.com/entry/2020/04/28/074534#GitHub-Action%E3%81%AE%E8%A8%AD%E5%AE%9A%E3%82%92%E3%81%99%E3%82%8B
+name: Static Analysis
+
+on: [push]
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:2.7.1
+    steps:
+      - uses: actions/checkout@v2 # これがないと bundle でエラーになる。何やってるのか分からない
+      - name: setup bundle
+        run: bundle install
+      - name: run rubocop
+        run: bundle exec rubocop

--- a/config/database.yml.ci
+++ b/config/database.yml.ci
@@ -1,0 +1,8 @@
+test:
+  adapter: mysql2
+  encoding: utf8mb4
+  username: root
+  password: password
+  host: localhost
+  database: github_actions_for_rails_test
+  reconnect: false


### PR DESCRIPTION
https://github.com/dobby618/tryout-miniblog/issues/14

- [ ] github actions
    - [x] rubocop
    - [ ] rspec
        - [【Github Actions】Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)](https://qiita.com/wancoro/items/403f924714feab77f007)
https://book-reviews.blog/github_actions_on_rails_application/
        - DB へのアクセスができなかった。socket, localhost, 127.0.0.1 で試したけどうまくいかず・・今回は断念する
- [x] heroku deploy
    - [LaravelでGitHub Actionsを利用してHerokuにデプロイする](https://qiita.com/nagi125/items/6b0fbef58b5b0ffea753#heroku%E5%81%B4%E3%81%AE%E8%A8%AD%E5%AE%9A)

---

次回 github action をやるなら
- キャッシュして欲しい（キャッシュ使わないと？遅いね。）
- runs-on, container, services の違いがわからない。全部 docker な気がしちゃうけど・・。
- heroku デプロイも github actions を使いたい
- rspec  も次回はできるようになりたい