### PR TITLE
毎朝7時に前日の「いいね」数ランキングが10位までの投稿が通知される

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,7 @@ Layout/LineLength:
 Metrics/BlockLength:
   Exclude:
     - config/environments/**/*
+    - spec/**/*
 
 ################
 # Rails #
@@ -82,3 +83,7 @@ Rails/FilePath:
 # 日本語でRspecを記述するので
 RSpec/ContextWording:
   Enabled: false
+
+# デフォルト 3 では少ないので
+RSpec/NestedGroups:
+  Max: 5

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ gem 'devise'
 # 画像アップロード
 gem 'carrierwave', '~> 2.0'
 gem 'cloudinary', group: :production
+# メールの css を inline css に変換する
+gem 'premailer-rails'
 
 # -- View --
 # テンプレートエンジン

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,8 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    css_parser (1.7.1)
+      addressable
     devise (4.7.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -126,6 +128,7 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    htmlentities (4.3.4)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -166,6 +169,13 @@ GEM
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
+    premailer (1.12.1)
+      addressable
+      css_parser (>= 1.6.0)
+      htmlentities (>= 4.0.0)
+    premailer-rails (1.11.1)
+      actionmailer (>= 3)
+      premailer (~> 1.7, >= 1.7.9)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -341,6 +351,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.2)
   mysql2 (>= 0.4.4)
+  premailer-rails
   pry-byebug
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)

--- a/app/mailers/article_mailer.rb
+++ b/app/mailers/article_mailer.rb
@@ -9,4 +9,10 @@ class ArticleMailer < ApplicationMailer
 
     mail(to: article.user.email, subject: 'コメントが届きました')
   end
+
+  def like_ranking_of_yesterday(to_user, articles)
+    @articles = articles
+
+    mail(to: to_user.email, subject: '昨日の「いいね」ランキング！')
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Article < ApplicationRecord
+  LIKE_RANKING_LIMIT_OF_YESTERDAY = 10
   mount_uploader :image, ArticleImageUploader
 
   belongs_to :user
@@ -9,6 +10,22 @@ class Article < ApplicationRecord
 
   validates :body, presence: true,
                    length: { maximum: 140 }
+
+  # rake タスク
+  # rails cron:notify_like_ranking_of_yesterday
+  def self.notify_like_ranking_of_yesterday
+    ranked_articles = like_ranking_of_yesterday
+    return if ranked_articles.count.zero?
+
+    User.all.find_each do |user|
+      ArticleMailer.like_ranking_of_yesterday(user, ranked_articles).deliver_now
+    end
+  end
+
+  def self.like_ranking_of_yesterday(limit = LIKE_RANKING_LIMIT_OF_YESTERDAY)
+    article_ids = Like.yesterday.group(:article_id).order(count_all: :desc).count.keys.take(limit)
+    where(id: article_ids).order([Arel.sql('field(id, ?)'), article_ids])
+  end
 
   def liked?(user)
     !likes.find_by(user: user).nil?

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -5,4 +5,6 @@ class Like < ApplicationRecord
   belongs_to :article, counter_cache: true
 
   validates :user, uniqueness: { scope: :article }
+
+  scope :yesterday, -> { where(created_at: Time.current.ago(1.day).all_day) }
 end

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -2,7 +2,8 @@
 %html
   %head
     %meta{:content => 'text/html; charset=utf-8', 'http-equiv' => 'Content-Type'}/
-    :css
-      /* Email styles need to be inline */
+    = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   %body
-    = yield
+    .container
+      = yield

--- a/app/views/mailers/article_mailer/like_ranking_of_yesterday.html.haml
+++ b/app/views/mailers/article_mailer/like_ranking_of_yesterday.html.haml
@@ -1,0 +1,7 @@
+%ul.list-group
+  %li.list-group-item.active
+    昨日の「いいね」ランキング！
+  - @articles.each.with_index(1) do |article, index|
+    %li.list-group-item
+      = "#{index}位"
+      = article.body

--- a/config/database.yml.ci
+++ b/config/database.yml.ci
@@ -1,8 +1,0 @@
-test:
-  adapter: mysql2
-  encoding: utf8mb4
-  username: root
-  password: password
-  host: localhost
-  database: github_actions_for_rails_test
-  reconnect: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,3 @@
 # frozen_string_literal: true
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+
+load(Rails.root.join('db', 'seeds', "#{Rails.env.downcase}.rb"))

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# ランキングバッチのためのテストデータ
+# 前日の「いいね」された記事を作成する
+FactoryBot.create_list(:article, 10) if Article.count < 10
+100.times do
+  Like.create(user_id: User.ids.sample,
+              article_id: Article.ids.sample,
+              created_at: DateTime.current.ago(1.day))
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :cron do
+  desc '前日の「いいね」ランキングをユーザに通知する'
+  task notify_like_ranking_of_yesterday: :environment do
+    Article.notify_like_ranking_of_yesterday
+  end
+end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :article do
     user
-    body { Faker::Name.name }
+    body { Faker::String.random }
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :comment do
     article
     user
-    body { Faker::Name.name }
+    body { Faker::String.random }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     name { Faker::Alphanumeric.alpha(number: 10) }
     email { Faker::Internet.email }
     password { Faker::Alphanumeric.alpha(number: 10) }
-    profile { Faker::Name.name }
+    profile { Faker::String.random }
     website { Faker::Internet.url }
   end
 end

--- a/spec/mailers/previews/article_mailer_preview.rb
+++ b/spec/mailers/previews/article_mailer_preview.rb
@@ -5,4 +5,8 @@ class ArticleMailerPreview < ActionMailer::Preview
   def commented
     ArticleMailer.commented(Article.first, Article.first.comments.last)
   end
+
+  def like_ranking_of_yesterday
+    ArticleMailer.like_ranking_of_yesterday(User.first, Article.like_ranking_of_yesterday)
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3,6 +3,86 @@
 require 'rails_helper'
 
 RSpec.describe Article, type: :model do
+  describe '#self.notify_like_ranking_of_yesterday' do # 前日の「いいね」ランキングを通知する
+    context '前日に「いいね」がある場合' do
+      before do
+        create(:like, created_at: Time.current.ago(1.day))
+      end
+
+      it '全ユーザに「いいね」ランキングメールを通知すること' do
+        expect do
+          described_class.notify_like_ranking_of_yesterday
+        end.to change(ActionMailer::Base.deliveries, :count).by(User.count)
+      end
+    end
+
+    context '前日に「いいね」がない場合' do
+      it '「いいね」ランキングメールを通知しないこと' do
+        expect do
+          described_class.notify_like_ranking_of_yesterday
+        end.not_to change(ActionMailer::Base.deliveries, :count)
+      end
+    end
+  end
+
+  describe '#self.like_ranking_of_yesterday' do # 昨日の「いいね」数順に並んだ上位 N 件
+    describe '昨日の「いいね」だけカウントする' do
+      context '昨日「いいね」が 10 件の article1 と一昨日「いいね」が 20 件の article2 があった場合' do
+        let(:article1) { create(:article) }
+        let(:article2) { create(:article) }
+
+        before do
+          create_list(:like, 10, article: article1, created_at: Time.current.ago(1.day))
+          create_list(:like, 20, article: article2, created_at: Time.current.ago(2.days))
+        end
+
+        it '1 位が article1 であること' do
+          expect(described_class.like_ranking_of_yesterday.first).to eq article1
+        end
+      end
+    end
+
+    describe '引数の指定' do
+      context '昨日「いいね」された記事数が 10 件以上の場合' do
+        before do
+          create_list(:like, 10, created_at: Time.current.ago(1.day))
+        end
+
+        context '引数を指定しない場合' do
+          it '10 件の記事が返ること' do
+            expect(described_class.like_ranking_of_yesterday.count).to eq 10
+          end
+        end
+
+        context '引数に 5 を指定した場合' do
+          it '5 件の記事が返ること' do
+            expect(described_class.like_ranking_of_yesterday(5).count).to eq 5
+          end
+        end
+      end
+    end
+
+    describe '記事の並び順' do
+      context '昨日「いいね」された記事が 2 件存在した場合' do
+        let(:article1) { create(:article) }
+        let(:article2) { create(:article) }
+
+        before do
+          create_list(:like, 10, article: article1, created_at: Time.current.ago(1.day))
+          create_list(:like, 20, article: article2, created_at: Time.current.ago(1.day))
+        end
+
+        it '1 位が article2 であること' do
+          expect(described_class.like_ranking_of_yesterday.first).to eq article2
+        end
+
+        it '2 位が article1 であること' do
+          expect(described_class.like_ranking_of_yesterday.second).to eq article1
+        end
+      end
+    end
+  end
+
   describe '#liked?' do # 「いいね」の可否
     let(:article) { create(:article) }
     let(:argument_user) { create(:user) }


### PR DESCRIPTION
https://github.com/dobby618/tryout-miniblog/issues/30

＜基本要件＞
- [x] 毎朝7時に前日の「いいね」数ランキングが10位までの投稿がメール通知されるようにする
    - [x] テストデータを自動で作れるようにする
[環境ごとに投入する初期データを変える](https://qiita.com/kimihito_/items/753390a5fe42a41b1d60)
    - [x] スクリプトはRakeタスク化すること
[Railsでバッチを書く時によく使うrails runnerとrake taskの違い](https://qiita.com/rllllho/items/672e336a03335cba6b34)
        - いいね数が同じ数だったらどうする？
→特に制御しない。SQL での取得順になり 10 件で切る。
        - いいねがなかったらどうする？メール流さないほうがいいよね？
→メール流さない
    - [x] スクリプトのテスト
- [x] メール内に投稿内容も記載されるようにする
- [x] メールはHTMLメールである程度見栄えがデザインされたものであること
[railsのmailerでcssファイルを使う＆画像も入れる](https://qiita.com/gymnstcs/items/978b7b4afee4d9a989ec)

＜技術的な要件＞
- [x] スクリプトの定期実行はHeroku Schedulerを利用すること
