### PR TITLE
heroku error 対応

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -47,3 +47,5 @@ test:
 #   production:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
+production:
+  <<: *default

--- a/db/migrate/20200711141502_add_likes_count_to_posts.rb
+++ b/db/migrate/20200711141502_add_likes_count_to_posts.rb
@@ -5,6 +5,8 @@ class AddLikesCountToPosts < ActiveRecord::Migration[6.0]
     add_column :posts, :likes_count, :integer, null: false, default: 0, after: :user_id
 
     # likes_count カラムに既存の「いいね」数を登録する
+    return unless Object.const_defined?(:Post)
+
     Post.all.each do |post|
       Post.reset_counters(post.id, :likes)
     end


### PR DESCRIPTION
- rename_table のある migration ファイルでエラー
- heroku restart した
- heroku restart したことで database.yml が反映し、消しても問題ないと思っていたのもの https://github.com/dobby618/tryout-miniblog/pull/29/files#diff-e31bdf70b15c8f84344c332efe06900dL50-L54 が問題あり、戻した。
heroku restart するまで気づかなかった。。設定ファイルを更新した場合は heroku restart が必要そう。
- heroku rake db:migrate:reset したら、今後は以下のエラーが出る。（これまで出たことなかったのに・・！）
```
Mysql2::Error: Specified key was too long; max key length is 767 bytes
```
→ ClearDB MySQL はデフォルトで 5.6 で 5.7 にバージョンアップするとお金がかかるので・・
https://devcenter.heroku.com/articles/cleardb#the-cleardb-dedicated-mysql-complete-tutorial-local-setup
デフォルト 5.7 の JawsDB を使う。
https://qiita.com/7kaji/items/c2538f5460c5243666d6